### PR TITLE
맥, 윈도우 간 개행 문제 오류 해결

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -32,6 +32,12 @@ module.exports = {
   plugins: ["react", "prettier"],
   rules: {
     "react/react-in-jsx-scope": "off",
+    "prettier/prettier": [
+      "error",
+      {
+        endOfLine: "auto",
+      },
+    ],
     // 다른 규칙들...
   },
 };


### PR DESCRIPTION
- eslintrc.js 에서 설정 값 추가로 CR과 CRLF 혼동이 없도록 수정